### PR TITLE
Feature/nmp

### DIFF
--- a/cli/state.cpp
+++ b/cli/state.cpp
@@ -97,6 +97,9 @@ void State::evaluate() const {
 
 static std::ostream& operator<<(std::ostream& stream, const std::vector<Move>& line) {
     for (Move m: line) {
+        if (m == MOVE_NULL) {
+            break;
+        }
         stream << m.to_uci() << ' ';
     }
     return stream;

--- a/illumina/board.cpp
+++ b/illumina/board.cpp
@@ -508,15 +508,20 @@ bool Board::is_attacked_by(Color c, Square s, Bitboard occ) const {
 void Board::make_null_move() {
     m_prev_states.push_back(m_state);
 
-    set_ep_square(SQ_NULL);
     set_color_to_move(opposite_color(color_to_move()));
+    set_ep_square(SQ_NULL);
+
+    compute_checkers();
+    compute_pins();
 }
 
 void Board::undo_null_move() {
+    set_color_to_move(opposite_color(color_to_move()));
+
     m_state = m_prev_states.back();
     m_prev_states.pop_back();
 
-    set_color_to_move(opposite_color(color_to_move()));
+    compute_pins();
 }
 
 void Board::compute_pins() {

--- a/illumina/searchdefs.h
+++ b/illumina/searchdefs.h
@@ -33,7 +33,7 @@ static_assert(MATE_SCORE       < MAX_SCORE);
 static_assert(MATE_THRESHOLD   < MATE_SCORE);
 
 constexpr Score is_mate_score(Score score) {
-    return score >= MATE_THRESHOLD;
+    return score >= MATE_THRESHOLD || score <= -MATE_THRESHOLD;
 }
 
 constexpr int plies_to_mate(Score score) {

--- a/tests/suites/board.cpp
+++ b/tests/suites/board.cpp
@@ -184,3 +184,177 @@ TEST_CASE(BoardFENConstructor) {
     EXPECT(frc_board_3.has_castling_rights(CL_BLACK, SIDE_QUEEN)).to_be(true);
 
 }
+
+TEST_CASE(MakeUndoNullMove) {
+    struct {
+        const char* fen;
+
+        void run() {
+            Board board(fen);
+            if (board.in_check() || !board.legal()) {
+                // Don't test null moves in check/illegal positions.
+                return;
+            }
+
+            std::string start_fen = board.fen();
+            ui64 start_key        = board.hash_key();
+            Color start_color     = board.color_to_move();
+
+            board.make_null_move();
+
+            EXPECT(board.legal()).to_be(true);
+            std::string null_fen = board.fen();
+            ui64 null_key        = board.hash_key();
+            Color null_color     = board.color_to_move();
+
+            board.undo_null_move();
+
+            EXPECT(board.legal()).to_be(true);
+            std::string curr_fen = board.fen();
+            ui64 curr_key        = board.hash_key();
+            Color curr_color     = board.color_to_move();
+
+            // Test against current values.
+            EXPECT(curr_fen).to_be(start_fen);
+            EXPECT(curr_color).to_be(start_color);
+            EXPECT(curr_key).to_be(start_key);
+
+            // Test against values during the null move.
+            EXPECT(null_fen).to_not_be(start_fen);
+            EXPECT(null_color).to_be(opposite_color(start_color));
+            EXPECT(null_key).to_not_be(start_key);
+        }
+
+    } tests[] = {
+        { "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1" },
+        { "r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1" },
+        { "4k3/8/8/8/8/8/8/4K2R w K - 0 1" },
+        { "4k3/8/8/8/8/8/8/R3K3 w Q - 0 1" },
+        { "4k2r/8/8/8/8/8/8/4K3 w k - 0 1" },
+        { "r3k3/8/8/8/8/8/8/4K3 w q - 0 1" },
+        { "4k3/8/8/8/8/8/8/R3K2R w KQ - 0 1" },
+        { "r3k2r/8/8/8/8/8/8/4K3 w kq - 0 1" },
+        { "8/8/8/8/8/8/6k1/4K2R w K - 0 1" },
+        { "8/8/8/8/8/8/1k6/R3K3 w Q - 0 1" },
+        { "4k2r/6K1/8/8/8/8/8/8 w k - 0 1" },
+        { "r3k3/1K6/8/8/8/8/8/8 w q - 0 1" },
+        { "r3k2r/8/8/8/8/8/8/R3K2R w KQkq - 0 1" },
+        { "r3k2r/8/8/8/8/8/8/1R2K2R w Kkq - 0 1" },
+        { "r3k2r/8/8/8/8/8/8/2R1K2R w Kkq - 0 1" },
+        { "r3k2r/8/8/8/8/8/8/R3K1R1 w Qkq - 0 1" },
+        { "1r2k2r/8/8/8/8/8/8/R3K2R w KQk - 0 1" },
+        { "2r1k2r/8/8/8/8/8/8/R3K2R w KQk - 0 1" },
+        { "r3k1r1/8/8/8/8/8/8/R3K2R w KQq - 0 1" },
+        { "4k3/8/8/8/8/8/8/4K2R b K - 0 1" },
+        { "4k3/8/8/8/8/8/8/R3K3 b Q - 0 1" },
+        { "4k2r/8/8/8/8/8/8/4K3 b k - 0 1" },
+        { "r3k3/8/8/8/8/8/8/4K3 b q - 0 1" },
+        { "4k3/8/8/8/8/8/8/R3K2R b KQ - 0 1" },
+        { "r3k2r/8/8/8/8/8/8/4K3 b kq - 0 1" },
+        { "8/8/8/8/8/8/6k1/4K2R b K - 0 1" },
+        { "8/8/8/8/8/8/1k6/R3K3 b Q - 0 1" },
+        { "4k2r/6K1/8/8/8/8/8/8 b k - 0 1" },
+        { "r3k3/1K6/8/8/8/8/8/8 b q - 0 1" },
+        { "r3k2r/8/8/8/8/8/8/R3K2R b KQkq - 0 1" },
+        { "r3k2r/8/8/8/8/8/8/1R2K2R b Kkq - 0 1" },
+        { "r3k2r/8/8/8/8/8/8/2R1K2R b Kkq - 0 1" },
+        { "r3k2r/8/8/8/8/8/8/R3K1R1 b Qkq - 0 1" },
+        { "1r2k2r/8/8/8/8/8/8/R3K2R b KQk - 0 1" },
+        { "2r1k2r/8/8/8/8/8/8/R3K2R b KQk - 0 1" },
+        { "r3k1r1/8/8/8/8/8/8/R3K2R b KQq - 0 1" },
+        { "8/1n4N1/2k5/8/8/5K2/1N4n1/8 w - - 0 1" },
+        { "8/1k6/8/5N2/8/4n3/8/2K5 w - - 0 1" },
+        { "8/8/4k3/3Nn3/3nN3/4K3/8/8 w - - 0 1" },
+        { "K7/8/2n5/1n6/8/8/8/k6N w - - 0 1" },
+        { "k7/8/2N5/1N6/8/8/8/K6n w - - 0 1" },
+        { "8/1n4N1/2k5/8/8/5K2/1N4n1/8 b - - 0 1" },
+        { "8/1k6/8/5N2/8/4n3/8/2K5 b - - 0 1" },
+        { "8/8/3K4/3Nn3/3nN3/4k3/8/8 b - - 0 1" },
+        { "K7/8/2n5/1n6/8/8/8/k6N b - - 0 1" },
+        { "k7/8/2N5/1N6/8/8/8/K6n b - - 0 1" },
+        { "B6b/8/8/8/2K5/4k3/8/b6B w - - 0 1" },
+        { "8/8/1B6/7b/7k/8/2B1b3/7K w - - 0 1" },
+        { "k7/B7/1B6/1B6/8/8/8/K6b w - - 0 1" },
+        { "K7/b7/1b6/1b6/8/8/8/k6B w - - 0 1" },
+        { "B6b/8/8/8/2K5/5k2/8/b6B b - - 0 1" },
+        { "8/8/1B6/7b/7k/8/2B1b3/7K b - - 0 1" },
+        { "k7/B7/1B6/1B6/8/8/8/K6b b - - 0 1" },
+        { "K7/b7/1b6/1b6/8/8/8/k6B b - - 0 1" },
+        { "7k/RR6/8/8/8/8/rr6/7K w - - 0 1" },
+        { "R6r/8/8/2K5/5k2/8/8/r6R w - - 0 1" },
+        { "7k/RR6/8/8/8/8/rr6/7K b - - 0 1" },
+        { "R6r/8/8/2K5/5k2/8/8/r6R b - - 0 1" },
+        { "6kq/8/8/8/8/8/8/7K w - - 0 1" },
+        { "6KQ/8/8/8/8/8/8/7k b - - 0 1" },
+        { "K7/8/8/3Q4/4q3/8/8/7k w - - 0 1" },
+        { "6qk/8/8/8/8/8/8/7K b - - 0 1" },
+        { "6KQ/8/8/8/8/8/8/7k b - - 0 1" },
+        { "K7/8/8/3Q4/4q3/8/8/7k b - - 0 1" },
+        { "8/8/8/8/8/K7/P7/k7 w - - 0 1" },
+        { "8/8/8/8/8/7K/7P/7k w - - 0 1" },
+        { "K7/p7/k7/8/8/8/8/8 w - - 0 1" },
+        { "7K/7p/7k/8/8/8/8/8 w - - 0 1" },
+        { "8/2k1p3/3pP3/3P2K1/8/8/8/8 w - - 0 1" },
+        { "8/8/8/8/8/K7/P7/k7 b - - 0 1" },
+        { "8/8/8/8/8/7K/7P/7k b - - 0 1" },
+        { "K7/p7/k7/8/8/8/8/8 b - - 0 1" },
+        { "7K/7p/7k/8/8/8/8/8 b - - 0 1" },
+        { "8/2k1p3/3pP3/3P2K1/8/8/8/8 b - - 0 1" },
+        { "8/8/8/8/8/4k3/4P3/4K3 w - - 0 1" },
+        { "4k3/4p3/4K3/8/8/8/8/8 b - - 0 1" },
+        { "8/8/7k/7p/7P/7K/8/8 w - - 0 1" },
+        { "8/8/k7/p7/P7/K7/8/8 w - - 0 1" },
+        { "8/8/3k4/3p4/3P4/3K4/8/8 w - - 0 1" },
+        { "8/3k4/3p4/8/3P4/3K4/8/8 w - - 0 1" },
+        { "8/8/3k4/3p4/8/3P4/3K4/8 w - - 0 1" },
+        { "k7/8/3p4/8/3P4/8/8/7K w - - 0 1" },
+        { "8/8/7k/7p/7P/7K/8/8 b - - 0 1" },
+        { "8/8/k7/p7/P7/K7/8/8 b - - 0 1" },
+        { "8/8/3k4/3p4/3P4/3K4/8/8 b - - 0 1" },
+        { "8/3k4/3p4/8/3P4/3K4/8/8 b - - 0 1" },
+        { "8/8/3k4/3p4/8/3P4/3K4/8 b - - 0 1" },
+        { "k7/8/3p4/8/3P4/8/8/7K b - - 0 1" },
+        { "7k/3p4/8/8/3P4/8/8/K7 w - - 0 1" },
+        { "7k/8/8/3p4/8/8/3P4/K7 w - - 0 1" },
+        { "k7/8/8/7p/6P1/8/8/K7 w - - 0 1" },
+        { "k7/8/7p/8/8/6P1/8/K7 w - - 0 1" },
+        { "k7/8/8/6p1/7P/8/8/K7 w - - 0 1" },
+        { "k7/8/6p1/8/8/7P/8/K7 w - - 0 1" },
+        { "k7/8/8/3p4/4p3/8/8/7K w - - 0 1" },
+        { "k7/8/3p4/8/8/4P3/8/7K w - - 0 1" },
+        { "7k/3p4/8/8/3P4/8/8/K7 b - - 0 1" },
+        { "7k/8/8/3p4/8/8/3P4/K7 b - - 0 1" },
+        { "k7/8/8/7p/6P1/8/8/K7 b - - 0 1" },
+        { "k7/8/7p/8/8/6P1/8/K7 b - - 0 1" },
+        { "k7/8/8/6p1/7P/8/8/K7 b - - 0 1" },
+        { "k7/8/6p1/8/8/7P/8/K7 b - - 0 1" },
+        { "k7/8/8/3p4/4p3/8/8/7K b - - 0 1" },
+        { "k7/8/3p4/8/8/4P3/8/7K b - - 0 1" },
+        { "7k/8/8/p7/1P6/8/8/7K w - - 0 1" },
+        { "7k/8/p7/8/8/1P6/8/7K w - - 0 1" },
+        { "7k/8/8/1p6/P7/8/8/7K w - - 0 1" },
+        { "7k/8/1p6/8/8/P7/8/7K w - - 0 1" },
+        { "k7/7p/8/8/8/8/6P1/K7 w - - 0 1" },
+        { "k7/6p1/8/8/8/8/7P/K7 w - - 0 1" },
+        { "3k4/3pp3/8/8/8/8/3PP3/3K4 w - - 0 1" },
+        { "7k/8/8/p7/1P6/8/8/7K b - - 0 1" },
+        { "7k/8/p7/8/8/1P6/8/7K b - - 0 1" },
+        { "7k/8/8/1p6/P7/8/8/7K b - - 0 1" },
+        { "7k/8/1p6/8/8/P7/8/7K b - - 0 1" },
+        { "k7/7p/8/8/8/8/6P1/K7 b - - 0 1" },
+        { "k7/6p1/8/8/8/8/7P/K7 b - - 0 1" },
+        { "3k4/3pp3/8/8/8/8/3PP3/3K4 b - - 0 1" },
+        { "8/Pk6/8/8/8/8/6Kp/8 w - - 0 1" },
+        { "n1n5/1Pk5/8/8/8/8/5Kp1/5N1N w - - 0 1" },
+        { "8/PPPk4/8/8/8/8/4Kppp/8 w - - 0 1" },
+        { "n1n5/PPPk4/8/8/8/8/4Kppp/5N1N w - - 0 1" },
+        { "8/Pk6/8/8/8/8/6Kp/8 b - - 0 1" },
+        { "n1n5/1Pk5/8/8/8/8/5Kp1/5N1N b - - 0 1" },
+        { "8/PPPk4/8/8/8/8/4Kppp/8 b - - 0 1" },
+        { "n1n5/PPPk4/8/8/8/8/4Kppp/5N1N b - - 0 1" },
+    };
+
+    for (auto& t: tests) {
+        t.run();
+    }
+}


### PR DESCRIPTION
Score of Illumina - New vs Illumina - Previous: 877 - 523 - 190  [0.611] 1590
...      Illumina - New playing White: 437 - 250 - 108  [0.618] 795
...      Illumina - New playing Black: 440 - 273 - 82  [0.605] 795
...      White vs Black: 710 - 690 - 190  [0.506] 1590
Elo difference: 78.7 +/- 16.4, LOS: 100.0 %, DrawRatio: 11.9 %
SPRT: llr 2.87 (99.2%), lbound -2.25, ubound 2.89