### PR TITLE
Killer moves.

### DIFF
--- a/illumina/movepicker.h
+++ b/illumina/movepicker.h
@@ -7,6 +7,18 @@
 #include "movegen.h"
 
 namespace illumina {
+
+class MoveHistory {
+public:
+    const std::array<Move, 2>& killers(Depth ply) const;
+    bool is_killer(Depth ply, Move move) const;
+    void set_killer(Depth ply, Move killer);
+    void reset();
+
+private:
+    std::array<std::array<Move, 2>, MAX_DEPTH> m_killers {};
+};
+
 template <bool QUIESCE = false>
 class MovePicker {
 public:
@@ -15,6 +27,8 @@ public:
     void score_move(SearchMove& move);
 
     explicit MovePicker(const Board& board,
+                        Depth ply,
+                        const MoveHistory& move_hist,
                         Move hash_move = MOVE_NULL);
 
 private:
@@ -22,11 +36,36 @@ private:
     Move         m_hash_move;
     size_t       m_count;
     const Board* m_board;
+    const MoveHistory* m_mv_hist;
+    Depth        m_ply;
 };
 
+
+inline const std::array<Move, 2>& MoveHistory::killers(Depth ply) const {
+    return m_killers[ply];
+}
+
+inline bool MoveHistory::is_killer(Depth ply, Move move) const {
+    const std::array<Move, 2>& arr = killers(ply);
+    return arr[0] == move || arr[1] == move;
+}
+
+inline void MoveHistory::set_killer(Depth ply, Move killer) {
+    std::array<Move, 2>& arr = m_killers[ply];
+    arr[1] = arr[0];
+    arr[0] = killer;
+}
+
+inline void MoveHistory::reset() {
+    std::fill(m_killers.begin(), m_killers.end(), std::array<Move, 2> { MOVE_NULL, MOVE_NULL });
+}
+
 template <bool QUIESCE>
-inline MovePicker<QUIESCE>::MovePicker(const Board& board, Move hash_move)
-    : m_board(&board), m_hash_move(hash_move) {
+inline MovePicker<QUIESCE>::MovePicker(const Board& board,
+                                       Depth ply,
+                                       const MoveHistory& move_hist,
+                                       Move hash_move)
+    : m_board(&board), m_ply(ply), m_hash_move(hash_move), m_mv_hist(&move_hist) {
     // Start by generating and counting all moves.
     SearchMove* end;
     if (m_board->in_check()) {
@@ -48,9 +87,13 @@ void MovePicker<QUIESCE>::score_move(SearchMove& move) {
     if (move == m_hash_move) {
         // Hash moves always receive maximum value.
         move.set_value(INT32_MAX);
+        return;
     }
-    else if (move.is_capture()) {
-        i32 value = 1024; // Start with base capture value.
+    if (move.is_promotion()) {
+        move.add_value(2048);
+    }
+    if (move.is_capture()) {
+        move.add_value(1024);
 
         // Perform MMV-LVA: Most valuable victims -> Least valuable attackers
         constexpr i32 MVV_LVA[PT_COUNT][PT_COUNT] {
@@ -64,9 +107,13 @@ void MovePicker<QUIESCE>::score_move(SearchMove& move) {
             /* Kx */ { 0,   100,  200,  300,  400,  500,  9999 },
         };
 
-        value += MVV_LVA[move.source()][move.destination()];
+        move.add_value(MVV_LVA[move.source()][move.destination()]);
+    }
 
-        move.set_value(value);
+    if (!move.is_promotion() && !move.is_capture()) {
+        if (m_mv_hist->is_killer(m_ply, move)) {
+            move.add_value(128);
+        }
     }
 }
 
@@ -113,6 +160,8 @@ template <bool QUIESCE>
 inline bool MovePicker<QUIESCE>::finished() const {
     return m_count == 0;
 }
+
+
 
 } // illumina
 

--- a/illumina/search.cpp
+++ b/illumina/search.cpp
@@ -88,10 +88,11 @@ private:
     const SearchContext*  m_context;
     WorkerResults         m_results;
 
-    Evaluation m_eval {};
-    Board      m_board;
-    bool       m_main;
-    Depth      m_curr_depth;
+    MoveHistory m_hist;
+    Evaluation  m_eval {};
+    Board       m_board;
+    bool        m_main;
+    Depth       m_curr_depth;
 
     Score quiescence_search(Depth ply, Score alpha, Score beta);
 
@@ -165,7 +166,7 @@ Score SearchWorker::quiescence_search(Depth ply, Score alpha, Score beta) {
         return alpha;
     }
 
-    MovePicker<true> move_picker(m_board);
+    MovePicker<true> move_picker(m_board, ply, m_hist);
     SearchMove move;
     while ((move = move_picker.next()) != MOVE_NULL) {
         make_move(move);
@@ -255,7 +256,7 @@ Score SearchWorker::pvs(Depth depth, Depth ply, Score alpha, Score beta) {
         }
     }
 
-    MovePicker move_picker(m_board, hash_move);
+    MovePicker move_picker(m_board, ply, m_hist, hash_move);
     Move move {};
     while ((move = move_picker.next()) != MOVE_NULL) {
         n_searched_moves++;
@@ -280,6 +281,10 @@ Score SearchWorker::pvs(Depth depth, Depth ply, Score alpha, Score beta) {
         if (score >= beta) {
             alpha     = beta;
             best_move = move;
+
+            if (!move.is_capture() && !move.is_promotion()) {
+                m_hist.set_killer(ply, move);
+            }
 
             if (ROOT && m_main && (!should_stop() || depth <= 2)) {
                 m_results.best_move = move;

--- a/illumina/searchdefs.h
+++ b/illumina/searchdefs.h
@@ -66,6 +66,8 @@ public:
 
     i32 value() const;
     void set_value(i32 val);
+    void add_value(i32 val);
+    void reduce_value(i32 val);
 
 private:
     i32 m_val;
@@ -90,6 +92,14 @@ inline i32 SearchMove::value() const {
 
 inline void SearchMove::set_value(i32 val) {
     m_val = val;
+}
+
+inline void SearchMove::add_value(i32 val) {
+    m_val += val;
+}
+
+inline void SearchMove::reduce_value(i32 val) {
+    m_val -= val;
 }
 
 }


### PR DESCRIPTION
Score of Illumina - New vs Illumina - Previous: 740 - 438 - 372  [0.597] 1550
...      Illumina - New playing White: 358 - 236 - 181  [0.579] 775
...      Illumina - New playing Black: 382 - 202 - 191  [0.616] 775
...      White vs Black: 560 - 618 - 372  [0.481] 1550
Elo difference: 68.6 +/- 15.3, LOS: 100.0 %, DrawRatio: 24.0 %
SPRT: llr 2.84 (98.4%), lbound -2.25, ubound 2.89