### PR TITLE
Reverse futility pruning.

### DIFF
--- a/illumina/search.cpp
+++ b/illumina/search.cpp
@@ -254,6 +254,16 @@ Score SearchWorker::pvs(Depth depth, Depth ply, Score alpha, Score beta) {
 
     Score static_eval = m_eval.get();
 
+    // Reverse futility pruning.
+    Score rfp_margin = 50 + 70 * depth;
+    if (!PV        &&
+        !in_check  &&
+        depth <= 7 &&
+        alpha < MATE_THRESHOLD &&
+        static_eval - rfp_margin > beta) {
+        return static_eval - rfp_margin;
+    }
+
     // Null move pruning.
     if (!PV        &&
         !SKIP_NULL &&


### PR DESCRIPTION
Score of Illumina - New vs Illumina - Previous: 933 - 684 - 1053  [0.547] 2670
...      Illumina - New playing White: 484 - 347 - 504  [0.551] 1335
...      Illumina - New playing Black: 449 - 337 - 549  [0.542] 1335
...      White vs Black: 821 - 796 - 1053  [0.505] 2670
Elo difference: 32.5 +/- 10.3, LOS: 100.0 %, DrawRatio: 39.4 %
SPRT: llr 2.86 (99.1%), lbound -2.25, ubound 2.89