### PR TITLE
SEE pruning.

### DIFF
--- a/illumina/search.cpp
+++ b/illumina/search.cpp
@@ -284,6 +284,14 @@ Score SearchWorker::pvs(Depth depth, Depth ply, Score alpha, Score beta) {
     MovePicker move_picker(m_board, ply, m_hist, hash_move);
     Move move {};
     while ((move = move_picker.next()) != MOVE_NULL) {
+        // SEE pruning.
+        if (depth <= 8          &&
+            !m_board.in_check() &&
+            move_picker.stage() > MPS_GOOD_CAPTURES &&
+            !has_good_see(m_board, move.source(), move.destination(), -2)) {
+            continue;
+        }
+
         make_move(move);
 
         // Late move reductions.


### PR DESCRIPTION
Score of Illumina - New vs Illumina - Previous: 1501 - 1241 - 1765  [0.529] 4507
...      Illumina - New playing White: 754 - 614 - 886  [0.531] 2254
...      Illumina - New playing Black: 747 - 627 - 879  [0.527] 2253
...      White vs Black: 1381 - 1361 - 1765  [0.502] 4507
Elo difference: 20.1 +/- 7.9, LOS: 100.0 %, DrawRatio: 39.2 %
SPRT: llr 2.89 (100.0%), lbound -2.25, ubound 2.89 - H1 was accepted