### PR TITLE
Stop doing TT cutoffs in PV nodes.

### DIFF
--- a/illumina/search.cpp
+++ b/illumina/search.cpp
@@ -15,7 +15,6 @@ static void init_search_constants() {
     for (size_t m = 0; m < MAX_GENERATED_MOVES; ++m) {
         for (Depth d = 0; d < MAX_DEPTH; ++d) {
             s_lmr_table[m][d] = Depth(1.25 + std::log(d) * std::log(m) * 100.0 / 267.0);
-
         }
     }
     for (Depth d = 0; d < MAX_DEPTH; ++d) {
@@ -251,7 +250,7 @@ Score SearchWorker::pvs(Depth depth, Score alpha, Score beta, SearchNode* parent
     if (found_in_tt) {
         hash_move = tt_entry.move();
 
-        if (tt_entry.depth() >= depth) {
+        if (!PV && tt_entry.depth() >= depth) {
             if (!ROOT && tt_entry.bound_type() == BT_EXACT) {
                 // TT Cuttoff. We found a TT entry that was searched in a depth higher or
                 // equal to ours, so we have an accurate score of this position and don't


### PR DESCRIPTION
Score of Illumina - New vs Illumina - Previous: 709 - 472 - 859  [0.558] 2040
...      Illumina - New playing White: 361 - 226 - 433  [0.566] 1020
...      Illumina - New playing Black: 348 - 246 - 426  [0.550] 1020
...      White vs Black: 607 - 574 - 859  [0.508] 2040
Elo difference: 40.5 +/- 11.5, LOS: 100.0 %, DrawRatio: 42.1 %
SPRT: llr 2.89 (100.0%), lbound -2.25, ubound 2.89