### PR TITLE
Reduced TT entry size.

### DIFF
--- a/illumina/searchdefs.h
+++ b/illumina/searchdefs.h
@@ -22,13 +22,11 @@ constexpr Depth MAX_DEPTH        = 128;
  * Limited by the number of bits dedicated to store the score
  * in a TT entry (currently 22).
  */
-constexpr Score SCORE_UPPERBOUND = BITMASK(20);
 constexpr Score MAX_SCORE        = 32005;
 constexpr Score MATE_SCORE       = MAX_SCORE - 1;
 constexpr Score MATE_THRESHOLD   = MATE_SCORE - 1024;
 
-static_assert(SCORE_UPPERBOUND < BITMASK(sizeof(Score) * 8));
-static_assert(MAX_SCORE        <= SCORE_UPPERBOUND);
+static_assert(MAX_SCORE        <= INT16_MAX);
 static_assert(MATE_SCORE       < MAX_SCORE);
 static_assert(MATE_THRESHOLD   < MATE_SCORE);
 

--- a/illumina/transpositiontable.cpp
+++ b/illumina/transpositiontable.cpp
@@ -31,7 +31,8 @@ void TranspositionTableEntry::replace(ui64 key,
                                       Depth depth,
                                       BoundType bound_type,
                                       ui8 generation) {
-    m_key   = key;
+    m_key_low = key & 0xFFFFFFFF;
+    m_key_hi  = key >> 32;
     m_move  = move;
     m_score = score;
 

--- a/illumina/transpositiontable.h
+++ b/illumina/transpositiontable.h
@@ -19,7 +19,8 @@ public:
     Depth     depth() const;
 
 private:
-    ui64 m_key;
+    ui32 m_key_low;
+    ui32 m_key_hi;
     Move m_move;
 
     // m_info  encoding:
@@ -29,7 +30,7 @@ private:
     //  11-18: depth
     ui32 m_info;
 
-    Score m_score;
+    i16 m_score;
 
     void replace(ui64 key, Move move,
                  Score score, Depth depth,
@@ -63,7 +64,7 @@ private:
 };
 
 inline ui64 TranspositionTableEntry::key() const {
-    return m_key;
+    return ui64(m_key_low) | (ui64(m_key_hi) << 32);
 }
 
 inline Move TranspositionTableEntry::move() const {

--- a/illumina/types.cpp
+++ b/illumina/types.cpp
@@ -213,7 +213,7 @@ Move::Move(const Board& board, Square src, Square dst, PieceType prom_piece_type
     }
     else if (src_piece.type() == PT_KING) {
         // For king moves, we must differentiate between regular moves
-        // or castles. Also, we have two supported encondings for castling:
+        // or castles. Also, we have two supported encodings for castling:
         //
         //  Encoding a: dst square is destination. Used for standard chess castling (e1g1, e1c1, e8c8, e8g8).
         //  Encoding b: dst square is castle rook source square. Used for FRC or standard.


### PR DESCRIPTION
Score of Illumina - New vs Illumina - Previous: 1898 - 1655 - 2927  [0.519] 6480
...      Illumina - New playing White: 954 - 838 - 1447  [0.518] 3239
...      Illumina - New playing Black: 944 - 817 - 1480  [0.520] 3241
...      White vs Black: 1771 - 1782 - 2927  [0.499] 6480
Elo difference: 13.0 +/- 6.3, LOS: 100.0 %, DrawRatio: 45.2 %
SPRT: llr 2.89 (99.9%), lbound -2.25, ubound 2.89