### PR TITLE
Check extensions.

### DIFF
--- a/illumina/search.cpp
+++ b/illumina/search.cpp
@@ -273,6 +273,11 @@ Score SearchWorker::pvs(Depth depth, Score alpha, Score beta, SearchNode* node) 
         }
     }
 
+    // Check extensions.
+    if (in_check) {
+        depth++;
+    }
+
     if (depth <= 0) {
         return quiescence_search(ply, alpha, beta);
     }
@@ -414,8 +419,9 @@ Score SearchWorker::pvs(Depth depth, Score alpha, Score beta, SearchNode* node) 
 
 void SearchWorker::aspiration_windows() {
     // Prepare the search stack.
-    SearchNode search_stack[MAX_DEPTH];
-    for (Depth ply = 0; ply < MAX_DEPTH; ++ply) {
+    constexpr size_t STACK_SIZE = MAX_DEPTH + 64;
+    SearchNode search_stack[STACK_SIZE];
+    for (Depth ply = 0; ply < STACK_SIZE; ++ply) {
         SearchNode& node = search_stack[ply];
         node.ply = ply;
     }


### PR DESCRIPTION
SPRT: llr 2.9 (100.4%), lbound -2.25, ubound 2.89 - H1 was accepted
Elo difference: 16.2 +/- 7.0, LOS: 100.0 %, DrawRatio: 44.1 %
Score of Illumina - New vs Illumina - Previous: 1589 - 1345 - 2310  [0.523] 5244