### PR TITLE
SEE pruning in qsearch.

### DIFF
--- a/illumina/search.cpp
+++ b/illumina/search.cpp
@@ -208,6 +208,12 @@ Score SearchWorker::quiescence_search(Depth ply, Score alpha, Score beta) {
     MovePicker<true> move_picker(m_board, ply, m_hist);
     SearchMove move;
     while ((move = move_picker.next()) != MOVE_NULL) {
+        // SEE pruning.
+        if (move_picker.stage() >= MPS_BAD_CAPTURES &&
+            !has_good_see(m_board, move.source(), move.destination(), -2)) {
+            continue;
+        }
+
         make_move(move);
         Score score = -quiescence_search(ply + 1, -beta, -alpha);
         undo_move();


### PR DESCRIPTION
SPRT: llr 2.9 (100.4%), lbound -2.25, ubound 2.89 - H1 was accepted
Elo difference: 22.3 +/- 8.3, LOS: 100.0 %, DrawRatio: 45.2 %
Score of Illumina - New vs Illumina - Previous: 1114 - 881 - 1647  [0.532] 3642