### PR TITLE
Futility pruning

### DIFF
--- a/illumina/search.cpp
+++ b/illumina/search.cpp
@@ -344,6 +344,16 @@ Score SearchWorker::pvs(Depth depth, Score alpha, Score beta, SearchNode* node) 
 
         make_move(move);
 
+        // Futility pruning.
+        if (depth <= 6 &&
+            !in_check  &&
+            !m_board.in_check() &&
+            move.is_quiet() &&
+            (static_eval + 80) < alpha) {
+            undo_move();
+            continue;
+        }
+
         // Late move reductions.
         Depth reductions = 0;
         if (n_searched_moves >= 1 &&


### PR DESCRIPTION
SPRT: llr 2.89 (100.1%), lbound -2.25, ubound 2.89 - H1 was accepted
Elo difference: 14.7 +/- 6.7, LOS: 100.0 %, DrawRatio: 45.1 %
Score of Illumina - New vs Illumina - Previous: 1691 - 1450 - 2576  [0.521] 5717