### PR TITLE
Add several uci reporting features.

### DIFF
--- a/cli/state.cpp
+++ b/cli/state.cpp
@@ -100,11 +100,17 @@ void State::evaluate() const {
 }
 
 static std::ostream& operator<<(std::ostream& stream, const std::vector<Move>& line) {
-    for (Move m: line) {
+    if (line.empty()) {
+        return stream;
+    }
+
+    std::cout << line[0].to_uci();
+    for (auto it = line.begin() + 1; it != line.end(); ++it) {
+        Move m = *it;
         if (m == MOVE_NULL) {
             break;
         }
-        stream << m.to_uci() << ' ';
+        stream << ' ' << m.to_uci();
     }
     return stream;
 }
@@ -127,15 +133,30 @@ static std::string bound_type_string(BoundType boundType) {
 }
 
 void State::setup_searcher() {
-    m_searcher.set_pv_finish_listener([](const PVResults& res) {
+    m_searcher.set_currmove_listener([this](Depth depth, Move move, int move_num) {
+        if (depth < 6 || delta_ms(Clock::now(), m_search_start) <= 3000) {
+            // Don't flood stdout on the first few seconds.
+            return;
+        }
+
         std::cout << "info"
-                  << " depth " << res.depth
-                  << " score " << score_string(res.score)
+                  << " depth "       << depth
+                  << " currmove "    << move.to_uci()
+                  << " currmovenumber " << move_num
+                  << std::endl;
+    });
+
+    m_searcher.set_pv_finish_listener([this](const PVResults& res) {
+        std::cout << "info"
+                  << " depth "    << res.depth
+                  << " seldepth " << res.sel_depth
+                  << " score "    << score_string(res.score)
                   << bound_type_string(res.bound_type)
-                  << " pv "    << res.line
-                  << "nodes "  << res.nodes
-                  << " nps "   << ui64((double(res.nodes) / (double(res.time) / 1000.0)))
-                  << " time "  << res.time
+                  << " pv "       << res.line
+                  << " hashfull " << m_searcher.tt().hash_full()
+                  << " nodes "    << res.nodes
+                  << " nps "      << ui64((double(res.nodes) / (double(res.time) / 1000.0)))
+                  << " time "     << res.time
                   << std::endl;
     });
 }
@@ -153,9 +174,16 @@ void State::search(SearchSettings settings) {
 
     m_search_thread = new std::thread([this, settings]() {
         try {
+            m_search_start = Clock::now();
             SearchResults results = m_searcher.search(m_board, settings);
 
-            std::cout << "bestmove " << results.best_move.to_uci() << std::endl;
+            std::cout << "bestmove " << results.best_move.to_uci();
+
+            if (results.ponder_move != MOVE_NULL) {
+                std::cout << " ponder " << results.ponder_move.to_uci();
+            }
+
+            std::cout << std::endl;
 
             m_searching = false;
         }
@@ -181,6 +209,9 @@ void State::register_options() {
             const auto& spin = dynamic_cast<const UCIOptionSpin&>(opt);
             m_searcher.tt().resize(spin.value() * 1024 * 1024);
         });
+
+    m_options.register_option<UCIOptionSpin>("Thread", 1, 1, 1);
+    m_options.register_option<UCIOptionSpin>("MultiPV", 1, 1, 1);
 }
 
 State::State() {

--- a/cli/state.h
+++ b/cli/state.h
@@ -44,6 +44,7 @@ private:
     Searcher         m_searcher;
     std::thread*     m_search_thread = nullptr;
     bool             m_searching = false;
+    TimePoint        m_search_start;
 
     void setup_searcher();
     void register_options();

--- a/illumina/search.h
+++ b/illumina/search.h
@@ -14,6 +14,7 @@ namespace illumina {
 
 struct PVResults {
     Depth depth;
+    Depth sel_depth;
     Move  best_move;
     Score score;
     ui64  nodes;
@@ -34,6 +35,7 @@ struct SearchSettings {
 
 struct SearchResults {
     Move  best_move;
+    Move  ponder_move;
     Score score;
 };
 
@@ -43,6 +45,7 @@ class Searcher {
 
 public:
     using PVFinishListener = std::function<void(PVResults&)>;
+    using CurrentMoveListener = std::function<void(Depth depth, Move move, int move_num)>;
 
     TranspositionTable& tt();
 
@@ -51,6 +54,7 @@ public:
     void stop();
 
     void set_pv_finish_listener(const PVFinishListener& listener);
+    void set_currmove_listener(const CurrentMoveListener& listener);
 
     Searcher() = default;
     Searcher(const Searcher& other) = delete;
@@ -67,12 +71,17 @@ private:
     TimeManager m_tm;
 
     struct Listeners {
-        PVFinishListener pv_finish = [](PVResults&) {};
+        PVFinishListener    pv_finish = [](PVResults&) {};
+        CurrentMoveListener curr_move_listener = [](Depth,Move,int) {};
     } m_listeners;
 };
 
 inline void Searcher::set_pv_finish_listener(const PVFinishListener& listener) {
     m_listeners.pv_finish = listener;
+}
+
+inline void Searcher::set_currmove_listener(const CurrentMoveListener& listener) {
+    m_listeners.curr_move_listener = listener;
 }
 
 inline Searcher::Searcher(TranspositionTable&& tt)

--- a/illumina/transpositiontable.h
+++ b/illumina/transpositiontable.h
@@ -47,6 +47,7 @@ public:
     void new_search();
     bool probe(ui64 key, TranspositionTableEntry& entry, Depth ply = 0);
     void try_store(ui64 key, Depth ply, Move move, Score score, Depth depth, BoundType bound_type);
+    int hash_full() const;
 
     explicit TranspositionTable(size_t size_bytes = TT_DEFAULT_SIZE_MB * 1024 * 1024);
     ~TranspositionTable() = default;
@@ -56,8 +57,9 @@ public:
 
 private:
     std::unique_ptr<TranspositionTableEntry[]> m_buf = nullptr;
-    size_t m_size;
-    size_t m_n_entries;
+    size_t m_size_in_bytes;
+    size_t m_max_entry_count;
+    size_t m_entry_count = 0;
     ui8 m_gen = 0;
 
     TranspositionTableEntry& entry_ref(ui64 key);
@@ -90,6 +92,11 @@ inline Depth TranspositionTableEntry::depth() const {
 inline Score TranspositionTableEntry::score() const {
     return m_score;
 }
+
+inline int TranspositionTable::hash_full() const {
+    return int(double(m_entry_count) / double(m_max_entry_count) * 1000);
+}
+
 
 } // illumina
 


### PR DESCRIPTION
Added info reports:
* `currmove` and `currmovenumber`
* `seldepth`
* `ponder` (on `bestmove` output, Illumina still doesn't support the ponder command)
* `hashfull`

Added UCI options (still cosmetic only, no effects on them yet):
* `Threads`
* `MultiPV`