### PR TITLE
Remove static evaluation on check positions.

### DIFF
--- a/illumina/search.cpp
+++ b/illumina/search.cpp
@@ -360,7 +360,7 @@ Score SearchWorker::pvs(Depth depth, Score alpha, Score beta, SearchNode* node) 
     }
 
     // Compute the static eval. Useful for many heuristics.
-    static_eval = m_eval.get();
+    static_eval = !in_check ? m_eval.get() : 0;
 
     // Reverse futility pruning.
     // If our position is too good, by a safe margin and low depth, prune.


### PR DESCRIPTION
SPRT: llr 2.89 (100.0%), lbound -2.25, ubound 2.89 - H1 was accepted
Elo difference: 36.7 +/- 10.9, LOS: 100.0 %, DrawRatio: 49.5 %
Score of Illumina - New vs Illumina - Previous: 600 - 393 - 973  [0.553] 1966