### PR TITLE
Add !in_check condition for LMR

### DIFF
--- a/illumina/search.cpp
+++ b/illumina/search.cpp
@@ -460,6 +460,7 @@ Score SearchWorker::pvs(Depth depth, Score alpha, Score beta, SearchNode* node) 
         if (n_searched_moves >= 1 &&
             depth >= 2            &&
             move.is_quiet()       &&
+            !in_check             &&
             !m_board.in_check()) {
             reductions += s_lmr_table[n_searched_moves - 1][depth];
         }


### PR DESCRIPTION
Score of Illumina - New vs Illumina - Previous: 4801 - 4532 - 9254  [0.507] 18587
...      Illumina - New playing White: 2392 - 2267 - 4635  [0.507] 9294
...      Illumina - New playing Black: 2409 - 2265 - 4619  [0.508] 9293
...      White vs Black: 4657 - 4676 - 9254  [0.499] 18587
Elo difference: 5.0 +/- 3.5, LOS: 99.7 %, DrawRatio: 49.8 %
SPRT: llr 2.9 (100.2%), lbound -2.25, ubound 2.89 - H1 was accepted