### PR TITLE
Additional reductions for LMR.

### DIFF
--- a/illumina/search.cpp
+++ b/illumina/search.cpp
@@ -477,7 +477,10 @@ Score SearchWorker::pvs(Depth depth, Score alpha, Score beta, SearchNode* node) 
             move.is_quiet()       &&
             !in_check             &&
             !m_board.in_check()) {
-            reductions += s_lmr_table[n_searched_moves - 1][depth];
+            reductions  = s_lmr_table[n_searched_moves - 1][depth];
+            reductions += !improving;
+            reductions += m_hist.quiet_history(move) <= -400;
+            reductions  = std::clamp(reductions, 0, depth);
         }
 
         Score score;


### PR DESCRIPTION
SPRT: llr 2.89 (100.1%), lbound -2.25, ubound 2.89 - H1 was accepted
Elo difference: 32.7 +/- 10.3, LOS: 100.0 %, DrawRatio: 52.0 %
Score of Illumina - New vs Illumina - Previous: 605 - 407 - 1097  [0.547] 2109