### PR TITLE
Feature/qsearch tt

### DIFF
--- a/illumina/search.cpp
+++ b/illumina/search.cpp
@@ -586,19 +586,6 @@ Score SearchWorker::quiescence_search(Depth ply, Score alpha, Score beta) {
             !hash_move.is_promotion()) {
             hash_move = MOVE_NULL;
         }
-
-        if constexpr (!PV) {
-            if (tt_entry.bound_type() == BT_EXACT) {
-                // TT Cuttoff.
-                return tt_entry.score();
-            }
-            else if (tt_entry.bound_type() == BT_LOWERBOUND) {
-                alpha = tt_entry.score();
-            }
-            else {
-                beta = tt_entry.score();
-            }
-        }
     }
 
     Score stand_pat = m_eval.get();


### PR DESCRIPTION
SPRT: llr 2.89 (100.1%), lbound -2.25, ubound 2.89 - H1 was accepted
Elo difference: 4.7 +/- 3.4, LOS: 99.7 %, DrawRatio: 55.4 %
Score of Illumina - New vs Illumina - Previous: 4140 - 3896 - 9984  [0.507] 18020