### PR TITLE
Reduce bad captures in stable positions in LMR

### DIFF
--- a/illumina/search.cpp
+++ b/illumina/search.cpp
@@ -478,13 +478,18 @@ Score SearchWorker::pvs(Depth depth, Score alpha, Score beta, SearchNode* node) 
         Depth reductions = 0;
         if (n_searched_moves >= 1 &&
             depth >= 2            &&
-            move.is_quiet()       &&
             !in_check             &&
             !m_board.in_check()) {
-            reductions  = s_lmr_table[n_searched_moves - 1][depth];
-            reductions += !improving;
-            reductions += m_hist.quiet_history(move) <= -400;
-            reductions  = std::clamp(reductions, 0, depth);
+            reductions = s_lmr_table[n_searched_moves - 1][depth];
+            if (move.is_quiet()) {
+                reductions += !improving;
+                reductions += m_hist.quiet_history(move) <= -400;
+            }
+            else if (move_picker.stage() == MPS_BAD_CAPTURES) {
+                bool stable = alpha >= 250;
+                reductions -= !stable * (reductions / 2);
+            }
+            reductions = std::clamp(reductions, 0, depth);
         }
 
         Score score;


### PR DESCRIPTION
SPRT: llr 2.9 (100.2%), lbound -2.25, ubound 2.89 - H1 was accepted
Elo difference: 7.1 +/- 4.4, LOS: 99.9 %, DrawRatio: 58.6 %
Score of Illumina - New vs Illumina - Previous: 2143 - 1941 - 5777  [0.510] 9861