### PR TITLE
Fix/no inc tc illegal moves

### DIFF
--- a/illumina/search.cpp
+++ b/illumina/search.cpp
@@ -256,7 +256,7 @@ SearchResults Searcher::search(const Board& board,
 void SearchWorker::iterative_deepening() {
     Depth max_depth = m_settings->max_depth.value_or(MAX_DEPTH);
     for (m_curr_depth = 1; m_curr_depth <= max_depth; ++m_curr_depth) {
-        if (should_stop() || m_context->time_manager().finished_soft()) {
+        if (should_stop() || (m_curr_depth > 2 && m_context->time_manager().finished_soft())) {
             break;
         }
 
@@ -280,7 +280,7 @@ void SearchWorker::iterative_deepening() {
             check_limits();
             aspiration_windows();
             check_limits();
-            if (should_stop() || m_context->time_manager().finished_soft()) {
+            if (should_stop() || (m_curr_depth > 2 && m_context->time_manager().finished_soft())) {
                 // If we finished soft, we don't want to start a new iteration.
                 break;
             }

--- a/illumina/timemanager.h
+++ b/illumina/timemanager.h
@@ -8,6 +8,8 @@
 
 namespace illumina {
 
+static constexpr int LAG_MARGIN = 20;
+
 class TimeManager {
 public:
     void start_movetime(ui64 movetime_ms);
@@ -77,7 +79,7 @@ inline void TimeManager::set_starting_bounds(ui64 soft, ui64 hard) {
 
 inline void TimeManager::start_movetime(ui64 movetime_ms) {
     setup(false);
-    ui64 bound = movetime_ms - 25;
+    ui64 bound = movetime_ms - LAG_MARGIN;
     set_starting_bounds(bound, bound);
 }
 
@@ -86,8 +88,8 @@ inline void TimeManager::start_tourney_time(ui64 our_time_ms,
                                             ui64 their_time_ms,
                                             ui64 their_inc_ms,
                                             int moves_to_go) {
-    ui64 max_time = our_time_ms - 25;
-    our_time_ms  += our_inc_ms * 45;
+    ui64 max_time = our_time_ms - LAG_MARGIN;
+    our_time_ms  += our_inc_ms * 45 - LAG_MARGIN;
     setup(true);
 
     if (moves_to_go != 1) {

--- a/illumina/timemanager.h
+++ b/illumina/timemanager.h
@@ -92,7 +92,7 @@ inline void TimeManager::start_tourney_time(ui64 our_time_ms,
 
     if (moves_to_go != 1) {
         set_starting_bounds(std::min(max_time, our_time_ms / 12),
-                            std::min(max_time, our_time_ms / 2));
+                            std::min(max_time, our_time_ms / 3));
     }
     else {
         set_starting_bounds(max_time, max_time);

--- a/illumina/types.cpp
+++ b/illumina/types.cpp
@@ -141,6 +141,10 @@ Piece Piece::from_char(char c) {
 }
 
 std::string Move::to_uci(bool frc) const {
+    if (*this == MOVE_NULL) {
+        return "0000";
+    }
+
     switch (type()) {
         case MT_SIMPLE_PROMOTION:
         case MT_PROMOTION_CAPTURE:


### PR DESCRIPTION
Only do soft timeout cutoffs in depths higher than 2, force legal moves in search return and adjust time manager.