### PR TITLE
Tighter alpha beta bounds when a non exact TT entry of higher depth is found.

### DIFF
--- a/illumina/search.cpp
+++ b/illumina/search.cpp
@@ -483,10 +483,10 @@ Score SearchWorker::pvs(Depth depth, Score alpha, Score beta, SearchNode* node) 
                 return tt_entry.score();
             }
             else if (tt_entry.bound_type() == BT_LOWERBOUND) {
-                alpha = tt_entry.score();
+                alpha = std::max(alpha, tt_entry.score());
             }
             else {
-                beta = tt_entry.score();
+                beta = std::min(beta, tt_entry.score());
             }
         }
     }


### PR DESCRIPTION
Decided not to keep test til the end since this is simply a "more correct" implementation and rather safe to merge.
Can be retested later.

SSS:

SPRT: llr 0.171 (5.9%), lbound -2.25, ubound 2.89
Elo difference: 2.6 +/- 8.6, LOS: 72.1 %, DrawRatio: 58.8 %
Score of Illumina - New vs Illumina - Previous: 537 - 518 - 1507  [0.504] 2562