### PR TITLE
Prune closed alpha beta bounds.

### DIFF
--- a/illumina/search.cpp
+++ b/illumina/search.cpp
@@ -448,6 +448,11 @@ Score SearchWorker::pvs(Depth depth, Score alpha, Score beta, SearchNode* node) 
         node->pv[0] = MOVE_NULL;
     }
 
+    // Don't search nodes with closed bounds.
+    if (!ROOT && alpha >= beta) {
+        return beta;
+    }
+
     // Keep track on some stats to report or use later.
     m_results.sel_depth = std::max(m_results.sel_depth, node->ply);
 


### PR DESCRIPTION
SPRT: llr 2.9 (100.5%), lbound -2.25, ubound 2.89 - H1 was accepted
Elo difference: 13.6 +/- 6.4, LOS: 100.0 %, DrawRatio: 63.0 %
Score of Illumina - New vs Illumina - Previous: 858 - 694 - 2637  [0.520] 4189