### PR TITLE
TT cutoff if AB bounds invert.

### DIFF
--- a/illumina/search.cpp
+++ b/illumina/search.cpp
@@ -504,6 +504,10 @@ Score SearchWorker::pvs(Depth depth, Score alpha, Score beta, SearchNode* node) 
             else {
                 beta = std::min(beta, tt_entry.score());
             }
+
+            if (alpha >= beta) {
+                return alpha;
+            }
         }
     }
 


### PR DESCRIPTION
SPRT: llr 2.9 (100.5%), lbound -2.25, ubound 2.89 - H1 was accepted
Elo difference: 13.1 +/- 6.3, LOS: 100.0 %, DrawRatio: 62.2 %
Score of Illumina - New vs Illumina - Previous: 925 - 757 - 2769  [0.519] 4451