### PR TITLE
Futility pruning speedup.

### DIFF
--- a/illumina/search.cpp
+++ b/illumina/search.cpp
@@ -624,17 +624,16 @@ Score SearchWorker::pvs(Depth depth, Score alpha, Score beta, SearchNode* node) 
             continue;
         }
 
-        make_move(move);
-
         // Futility pruning.
-        if (depth <= FP_MAX_DEPTH &&
-            !in_check             &&
-            !m_board.in_check()   &&
-            move.is_quiet()       &&
-            (static_eval + FP_MARGIN) < alpha) {
-            undo_move();
+        if (depth <= FP_MAX_DEPTH      &&
+            !in_check                  &&
+            move.is_quiet()            &&
+            (static_eval + FP_MARGIN) < alpha &&
+            !m_board.gives_check(move)) {
             continue;
         }
+
+        make_move(move);
 
         // Late move reductions.
         Depth reductions = 0;


### PR DESCRIPTION
Score of Illumina - New vs Illumina - Previous: 504 - 340 - 1295  [0.538] 2139
...      Illumina - New playing White: 276 - 165 - 628  [0.552] 1069
...      Illumina - New playing Black: 228 - 175 - 667  [0.525] 1070
...      White vs Black: 451 - 393 - 1295  [0.514] 2139
Elo difference: 26.7 +/- 9.2, LOS: 100.0 %, DrawRatio: 60.5 %
SPRT: llr 2.89 (100.0%), lbound -2.25, ubound 2.89 - H1 was accepted