### PR TITLE
Added king defenders to get_defenders.

### DIFF
--- a/illumina/boardutils.cpp
+++ b/illumina/boardutils.cpp
@@ -107,7 +107,8 @@ static Bitboard get_defenders(const Board& board,
                               Color c,
                               Bitboard occ) {
     return
-          (queen_attacks(s, occ)  & board.piece_bb(Piece(c, PT_QUEEN)))
+          (king_attacks(s)        & board.piece_bb(Piece(c, PT_KING)))
+        | (queen_attacks(s, occ)  & board.piece_bb(Piece(c, PT_QUEEN)))
         | (rook_attacks(s, occ)   & board.piece_bb(Piece(c, PT_ROOK)))
         | (bishop_attacks(s, occ) & board.piece_bb(Piece(c, PT_BISHOP)))
         | (knight_attacks(s)      & board.piece_bb(Piece(c, PT_KNIGHT)))

--- a/illumina/movepicker.h
+++ b/illumina/movepicker.h
@@ -453,7 +453,7 @@ void MovePicker<QUIESCE>::score_move(SearchMove& move) {
             move.add_value(-MV_PICKER_QUIET_DANGER_MALUS);
         }
 
-        // Decrease score of moves that move away from the center.
+        // Slightly decrease score of moves that move away from the center.
         Color us = move.source_piece().color();
         Square destination = move.destination();
         BoardFile file = square_file(destination);


### PR DESCRIPTION
SPRT: llr 1.38 (47.6%), lbound -2.25, ubound 2.89
Elo difference: 3.2 +/- 3.7, LOS: 95.6 %, DrawRatio: 67.6 %
Score of Illumina - New vs Illumina - Previous: 1809 - 1708 - 7349  [0.505] 10866