### PR TITLE
Discovered attack detection in SEE pruning and Move Ordering.

### DIFF
--- a/illumina/boardutils.h
+++ b/illumina/boardutils.h
@@ -23,6 +23,10 @@ bool attacks_vulnerable_pieces(const Board& board,
                                Square source,
                                Square dest);
 
+Bitboard discovered_attacks(const Board& board,
+                            Square source,
+                            Square dest);
+
 } // illumina
 
 #endif // ILLUMINA_BOARDUTILS_H

--- a/illumina/search.cpp
+++ b/illumina/search.cpp
@@ -635,8 +635,14 @@ Score SearchWorker::pvs(Depth depth, Score alpha, Score beta, SearchNode* node) 
             continue;
         }
 
+        Color them = opposite_color(m_board.color_to_move());
+        Bitboard discovered_atks = discovered_attacks(m_board, move.source(), move.destination());
+        Bitboard their_valuable_pieces = m_board.piece_bb(Piece(them, PT_KING))
+                                         | m_board.piece_bb(Piece(them, PT_QUEEN))
+                                         | m_board.piece_bb(Piece(them, PT_ROOK));
         // SEE pruning.
         if (   (!PV || m_root_depth > SEE_PRUNING_MAX_DEPTH)
+            && (discovered_atks & their_valuable_pieces) == 0
             && depth <= SEE_PRUNING_MAX_DEPTH
             && !m_board.in_check()
             && move_picker.stage() > MPS_GOOD_CAPTURES

--- a/tests/suites/boardutils.cpp
+++ b/tests/suites/boardutils.cpp
@@ -32,3 +32,25 @@ TEST_CASE(HasGoodSee) {
         test.run();
     }
 }
+
+TEST_CASE(RevealedAttacks) {
+    struct {
+        std::string board_fen;
+        Square source;
+        Square destination;
+        Bitboard expected;
+
+        void run() const {
+            Board board(board_fen);
+
+            Bitboard revealed_atks = discovered_attacks(board, source, destination);
+            EXPECT(revealed_atks).to_be(expected);
+        }
+    } tests[] = {
+        {"1k6/8/8/1q2n3/2n5/8/1P2P3/1K2RB2 w - - 0 1", SQ_E2, SQ_E4, 0x4000000 }
+    };
+
+    for (const auto& test: tests) {
+        test.run();
+    }
+}

--- a/tests/suites/movepicker.cpp
+++ b/tests/suites/movepicker.cpp
@@ -124,7 +124,7 @@ void test_move_picker() {
                     // Save all history.
                     for (auto& h: history) {
                         auto [depth, src, dest] = h;
-                        mv_hist.update_quiet_history(Move::new_normal(src, dest, WHITE_QUEEN), MOVE_NULL, depth, true);
+                        mv_hist.update_quiet_history(Move::new_normal(src, dest, WHITE_QUEEN), MOVE_NULL, depth, random_bool(), true);
                     }
                 }
             }
@@ -161,7 +161,7 @@ void test_move_picker() {
                     for (int i = 0; i < 100; ++i) {
                         // Pick a move.
                         Move move = validation_moves[random(size_t(0), n_expected_moves)];
-                        mv_hist.update_quiet_history(move, MOVE_NULL, random(1, 15), true);
+                        mv_hist.update_quiet_history(move, MOVE_NULL, random(1, 15), random_bool(), true);
                     }
                 }
                 else {


### PR DESCRIPTION
Score of Illumina - New vs Illumina - Previous: 1033 - 870 - 3403  [0.515] 5306
...      Illumina - New playing White: 537 - 425 - 1691  [0.521] 2653
...      Illumina - New playing Black: 496 - 445 - 1712  [0.510] 2653
...      White vs Black: 982 - 921 - 3403  [0.506] 5306
Elo difference: 10.7 +/- 5.6, LOS: 100.0 %, DrawRatio: 64.1 %
SPRT: llr 2.89 (100.2%), lbound -2.25, ubound 2.89 - H1 was accepted