### PR TITLE
Skip NMP in pawn endgames.

### DIFF
--- a/illumina/boardutils.cpp
+++ b/illumina/boardutils.cpp
@@ -247,4 +247,11 @@ Bitboard discovered_attacks(const Board& board,
     return revealed;
 }
 
+Bitboard non_pawn_bb(const Board& board) {
+    Bitboard occupancy = board.occupancy();
+    Bitboard kings     = board.piece_type_bb(PT_KING);
+    Bitboard pawns     = board.piece_type_bb(PT_PAWN);
+    return occupancy & (~kings) & (~pawns);
+}
+
 } // illumina

--- a/illumina/boardutils.h
+++ b/illumina/boardutils.h
@@ -27,6 +27,11 @@ Bitboard discovered_attacks(const Board& board,
                             Square source,
                             Square dest);
 
+/*
+ * Returns the bitboard of non-pawn pieces, excluding kings as well.
+ */
+Bitboard non_pawn_bb(const Board& board);
+
 } // illumina
 
 #endif // ILLUMINA_BOARDUTILS_H

--- a/illumina/search.cpp
+++ b/illumina/search.cpp
@@ -553,6 +553,7 @@ Score SearchWorker::pvs(Depth depth, Score alpha, Score beta, SearchNode* node) 
     if (   !PV
         && !SKIP_NULL
         && !in_check
+        && non_pawn_bb(m_board) != 0
         && popcount(m_board.color_bb(us)) >= NMP_MIN_PIECES
         && static_eval >= beta
         && depth >= NMP_MIN_DEPTH


### PR DESCRIPTION
SPRT: llr 2.9 (100.3%), lbound -2.25, ubound 2.89 - H1 was accepted
Elo difference: 8.7 +/- 4.9, LOS: 100.0 %, DrawRatio: 67.2 %
Score of Illumina - New vs Illumina - Previous: 1090 - 936 - 4156  [0.512] 6182