### PR TITLE
Add static eval cache in tt entries.

### DIFF
--- a/illumina/search.cpp
+++ b/illumina/search.cpp
@@ -534,7 +534,12 @@ Score SearchWorker::pvs(Depth depth, Score alpha, Score beta, SearchNode* node) 
     }
 
     // Compute the static eval. Useful for many heuristics.
-    static_eval    = !in_check ? evaluate() : 0;
+    if (!in_check) {
+        static_eval = !found_in_tt ? evaluate() : tt_entry.static_eval();
+    }
+    else {
+        static_eval = 0;
+    }
     bool improving = ply > 2 && !in_check && ((node - 2)->static_eval < static_eval);
 
     // Reverse futility pruning.
@@ -812,13 +817,16 @@ Score SearchWorker::pvs(Depth depth, Score alpha, Score beta, SearchNode* node) 
     if (node->skip_move == MOVE_NULL) {
         if (alpha >= beta) {
             // Beta-Cutoff, lowerbound score.
-            tt.try_store(board_key, ply, best_move, alpha, depth, BT_LOWERBOUND);
+            tt.try_store(board_key, ply, best_move, alpha, depth, static_eval, BT_LOWERBOUND);
         } else if (alpha <= original_alpha) {
             // Couldn't raise alpha, score is an upperbound.
-            tt.try_store(board_key, ply, best_move, n_searched_moves > 0 ? best_score : alpha, depth, BT_UPPERBOUND);
+            tt.try_store(board_key,
+                         ply, best_move,
+                         n_searched_moves > 0 ? best_score : alpha,
+                         depth, static_eval, BT_UPPERBOUND);
         } else {
             // We have an exact score.
-            tt.try_store(board_key, ply, best_move, alpha, depth, BT_EXACT);
+            tt.try_store(board_key, ply, best_move, alpha, depth, static_eval, BT_EXACT);
         }
     }
 

--- a/illumina/transpositiontable.h
+++ b/illumina/transpositiontable.h
@@ -17,6 +17,7 @@ public:
     ui8       generation() const;
     Score     score() const;
     Depth     depth() const;
+    Score     static_eval() const;
 
 private:
     ui32 m_key_low;
@@ -31,9 +32,11 @@ private:
     ui32 m_info;
 
     i16 m_score;
+    i16 m_static_eval;
 
     void replace(ui64 key, Move move,
                  Score score, Depth depth,
+                 i16 static_eval,
                  BoundType bound_type,
                  ui8 generation);
 };
@@ -46,7 +49,13 @@ public:
     void resize(size_t new_size_bytes);
     void new_search();
     bool probe(ui64 key, TranspositionTableEntry& entry, Depth ply = 0);
-    void try_store(ui64 key, Depth ply, Move move, Score score, Depth depth, BoundType bound_type);
+    void try_store(ui64 key,
+                   Depth ply,
+                   Move move,
+                   Score score,
+                   Depth depth,
+                   Score static_eval,
+                   BoundType bound_type);
     int hash_full() const;
 
     explicit TranspositionTable(size_t size_bytes = TT_DEFAULT_SIZE_MB * 1024 * 1024);
@@ -91,6 +100,10 @@ inline Depth TranspositionTableEntry::depth() const {
 
 inline Score TranspositionTableEntry::score() const {
     return m_score;
+}
+
+inline Score TranspositionTableEntry::static_eval() const {
+    return m_static_eval;
 }
 
 inline int TranspositionTable::hash_full() const {


### PR DESCRIPTION
Incomplete SPRT at around +2 elo (w/ +-3 error bars), but same bench.
Probably better results with larger nets.