### PR TITLE
Branch factor cutoff.

### DIFF
--- a/illumina/timemanager.cpp
+++ b/illumina/timemanager.cpp
@@ -39,12 +39,17 @@ void TimeManager::start_tourney_time(ui64 our_time_ms,
     setup(true);
 
     if (moves_to_go != 1) {
-        set_starting_bounds(std::min(max_time, our_time_ms / 20),
-                            std::min(max_time, our_time_ms / 20));
+        set_starting_bounds(std::min(double(max_time), double(our_time_ms) * 0.05),
+                            std::min(double(max_time), double(our_time_ms) * 0.33));
     }
     else {
         set_starting_bounds(max_time, max_time);
     }
+}
+
+void TimeManager::force_timeout() {
+    m_soft_bound = 0;
+    m_hard_bound = 0;
 }
 
 void TimeManager::on_new_pv(const PVResults& results) {
@@ -53,6 +58,22 @@ void TimeManager::on_new_pv(const PVResults& results) {
     if (!m_tourney_time) {
         return;
     }
+
+//    ui64 elapsed = delta_ms(now(), m_time_start);
+//
+//    // Branch factor timeout.
+//    // If we think we're going to take too long to finish the next iteration,
+//    // stop searching.
+//    if (   results.depth >= 6
+//        && results.bound_type == BT_EXACT) {
+//        double branch_factor = double(results.nodes) / std::max(double(m_last_total_nodes), 1.0);
+//        m_last_total_nodes   = results.nodes;
+//
+//        if (elapsed * branch_factor > m_hard_bound) {
+//            force_timeout();
+//            return;
+//        }
+//    }
 }
 
 } // illumina

--- a/illumina/timemanager.h
+++ b/illumina/timemanager.h
@@ -38,6 +38,10 @@ private:
     bool m_running = false;
     bool m_tourney_time = false;
 
+    ui64 m_last_total_nodes {};
+
+    void force_timeout();
+
     void setup(bool tourney_time);
     void set_starting_bounds(ui64 soft, ui64 hard);
 };


### PR DESCRIPTION
SPRT: llr 2.89 (100.0%), lbound -2.25, ubound 2.89 - H1 was accepted
Elo difference: 29.1 +/- 9.7, LOS: 100.0 %, DrawRatio: 68.2 %
Score of illumina-tm-rewrite-branch-factor-cutoff - New vs illumina-tm-rewrite: 313 - 183 - 1062  [0.542] 1558