### PR TITLE
int16 histories

### DIFF
--- a/illumina/movehistory.h
+++ b/illumina/movehistory.h
@@ -76,8 +76,9 @@ private:
         ButterflyArray<i16> butterfly {};
         std::array<std::array<PieceToArray<i16>, 2>, 2> threat_history {};
         PieceToArray<PieceToArray<i16>> counter_move_history {};
+        
         // PT_COUNT - 2 since we exclude kings and PT_NULL
-        PieceToArray<std::array<int, PT_COUNT - 2>> capt_hist {};
+        PieceToArray<std::array<i16, PT_COUNT - 2>> capt_hist {};
     };
     std::unique_ptr<Data> m_data = std::make_unique<Data>();
 

--- a/illumina/movehistory.h
+++ b/illumina/movehistory.h
@@ -73,10 +73,9 @@ private:
         CorrhistTable pawn_corrhist;
         CorrhistTable non_pawn_corrhist;
         std::array<std::array<Move, 2>, MAX_DEPTH> killers {};
-        ButterflyArray<int> butterfly {};
-        std::array<std::array<PieceToArray<int>, 2>, 2> threat_history {};
-        PieceToArray<PieceToArray<int>> counter_move_history {};
-
+        ButterflyArray<i16> butterfly {};
+        std::array<std::array<PieceToArray<i16>, 2>, 2> threat_history {};
+        PieceToArray<PieceToArray<i16>> counter_move_history {};
         // PT_COUNT - 2 since we exclude kings and PT_NULL
         PieceToArray<std::array<int, PT_COUNT - 2>> capt_hist {};
     };
@@ -88,11 +87,11 @@ private:
                                int depth_score,
                                int diff);
 
-    static void update_history_by_depth(int& history,
+    static void update_history_by_depth(i16& history,
                                         Depth depth,
                                         bool good);
 
-    static void update_history(int& history,
+    static void update_history(i16& history,
                                int bonus);
 };
 
@@ -229,7 +228,7 @@ inline int MoveHistory::correct_eval_with_corrhist(const Board& board,
                       -KNOWN_WIN, KNOWN_WIN);
 }
 
-inline void MoveHistory::update_history_by_depth(int& history,
+inline void MoveHistory::update_history_by_depth(i16& history,
                                                  Depth depth,
                                                  bool good) {
     int delta = (depth < MV_HIST_QUIET_HIGH_DEPTH_THRESHOLD)
@@ -239,7 +238,7 @@ inline void MoveHistory::update_history_by_depth(int& history,
     update_history(history, sign * delta);
 }
 
-inline void MoveHistory::update_history(int& history, int bonus) {
+inline void MoveHistory::update_history(i16& history, int bonus) {
     int clamped_bonus = std::clamp(bonus, -MAX_HISTORY, MAX_HISTORY);
     history          += clamped_bonus - history * std::abs(clamped_bonus) / MAX_HISTORY;
 }


### PR DESCRIPTION
```
Elo   | 2.02 +- 2.26 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.89 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 20154 W: 4382 L: 4265 D: 11507
Penta | [82, 1860, 6072, 1985, 78]
```
https://furybench.com/test/7120/